### PR TITLE
Tgb61 buildings creation/upgrade

### DIFF
--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/controllers/BuildingController.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/controllers/BuildingController.java
@@ -93,8 +93,7 @@ public class BuildingController {
       return ResponseEntity.status(404).body(new ErrorMessage("No building with such id found in your kingdom!"));
     }
 
-
-    if (!buildingService.isValidLevel(levelDTO.getLevel(), buildingToUpgrade.getLevel(), kingdom.getId(), buildingToUpgrade.getType())){
+    if (!buildingService.isValidLevel(levelDTO.getLevel(), buildingToUpgrade.getLevel(), kingdom.getId(), buildingToUpgrade.getType())) {
       return ResponseEntity.status(406).body(new ErrorMessage("Invalid building level: can upgrade only 1 grade at a time, and other buildings level must be less than or equal with townhall level!"));
     }
 
@@ -102,12 +101,12 @@ public class BuildingController {
       return ResponseEntity.status(409).body(new ErrorMessage("Not enough resource!"));
     }
 
-    if (buildingToUpgrade.getType().equals(BuildingTypeENUM.TOWNHALL)){
+    if (buildingToUpgrade.getType().equals(BuildingTypeENUM.TOWNHALL)) {
       Townhall upgradedTownhall = buildingService.upgradeTownhall(kingdom.getId(), id, levelDTO.getLevel());
       return ResponseEntity.status(200).body(buildingService.createBuildingDTO(upgradedTownhall));
     }
 
-    if (buildingToUpgrade.getType().equals(BuildingTypeENUM.MINE) || buildingToUpgrade.getType().equals(BuildingTypeENUM.FARM)){
+    if (buildingToUpgrade.getType().equals(BuildingTypeENUM.MINE) || buildingToUpgrade.getType().equals(BuildingTypeENUM.FARM)) {
       ProductionBuilding upgradedProductionBuilding = buildingService.upgradeProductionBuilding(kingdom.getId(), id, levelDTO.getLevel());
       return ResponseEntity.status(200).body(buildingService.createBuildingDTO(upgradedProductionBuilding));
     }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/controllers/KingdomController.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/controllers/KingdomController.java
@@ -25,7 +25,7 @@ public class KingdomController {
     this.kingdomService = kingdomService;
   }
 
-  @ApiImplicitParams({@ApiImplicitParam(name = "token", value = "Authorization token",required = true, dataType = "string", paramType = "header")})
+  @ApiImplicitParams({@ApiImplicitParam(name = "token", value = "Authorization token", required = true, dataType = "string", paramType = "header")})
   @ApiResponses(value = {@ApiResponse(code = 200, message = "OK", response = KingdomDTO.class)})
   @GetMapping("/kingdom")
   public ResponseEntity<Object> findOwnKingdom() {

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/controllers/LeaderboardController.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/controllers/LeaderboardController.java
@@ -1,6 +1,5 @@
 package com.greenfoxacademy.goddesstribesbackend.controllers;
 
-import com.greenfoxacademy.goddesstribesbackend.models.MockData;
 import com.greenfoxacademy.goddesstribesbackend.models.dtos.LeaderboardBuildingsDTO;
 import com.greenfoxacademy.goddesstribesbackend.models.dtos.LeaderboardByBuildingsDTO;
 import com.greenfoxacademy.goddesstribesbackend.models.dtos.LeaderboardBySoldiersDTO;
@@ -12,7 +11,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -41,4 +39,5 @@ public class LeaderboardController {
     LeaderboardBySoldiersDTO leaderboardBySoldiersDTO = leaderboardService.createLeaderboardBySoldiers();
     return ResponseEntity.status(200).body(leaderboardBySoldiersDTO);
   }
+
 }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/models/entities/Soldier.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/models/entities/Soldier.java
@@ -8,6 +8,7 @@ public class Soldier {
 
   private static final int START_LEVEL = 1;
   private static final int START_CONSUMPTION_RATE = 1;
+  public static final int CONSUMPTION_RATE_PER_LEVEL = 1;
   public static final int CREATION_COST = 10;
   public static final int UPGRADING_COST = 5;
   public static final int NEEDED_TIME = 1;

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/repositories/TownhallRepository.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/repositories/TownhallRepository.java
@@ -12,5 +12,4 @@ public interface TownhallRepository extends CrudRepository<Townhall, Long> {
   ArrayList<Townhall> findAll();
   ArrayList<Townhall> findTownhallsByKingdom_Id(Long kingdomId);
   Optional<Townhall> findById(Long townhallId);
-
 }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/security/WebSecurityConfig.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/security/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.greenfoxacademy.goddesstribesbackend.security;
 
 import com.greenfoxacademy.goddesstribesbackend.security.jwt.JWTAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,10 +17,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
-//  @Bean
-//  public RestAuthenticationEntryPoint restAuthenticationEntryPoint() {
-//    return new RestAuthenticationEntryPoint();
-//  }
+  @Bean
+  public RestAuthenticationEntryPoint restAuthenticationEntryPoint() {
+    return new RestAuthenticationEntryPoint();
+  }
 
   private static final String[] AUTH_WHITELIST = {
       // -- swagger ui

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/security/WebSecurityConfig.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/security/WebSecurityConfig.java
@@ -2,7 +2,6 @@ package com.greenfoxacademy.goddesstribesbackend.security;
 
 import com.greenfoxacademy.goddesstribesbackend.security.jwt.JWTAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,7 +15,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Autowired
   private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
-//
+
 //  @Bean
 //  public RestAuthenticationEntryPoint restAuthenticationEntryPoint() {
 //    return new RestAuthenticationEntryPoint();

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/security/WebSecurityConfig.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/security/WebSecurityConfig.java
@@ -2,7 +2,6 @@ package com.greenfoxacademy.goddesstribesbackend.security;
 
 import com.greenfoxacademy.goddesstribesbackend.security.jwt.JWTAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -17,10 +16,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
   @Autowired
   private RestAuthenticationEntryPoint restAuthenticationEntryPoint;
 
-  @Bean
-  public RestAuthenticationEntryPoint restAuthenticationEntryPoint() {
-    return new RestAuthenticationEntryPoint();
-  }
+//  @Bean
+//  public RestAuthenticationEntryPoint restAuthenticationEntryPoint() {
+//    return new RestAuthenticationEntryPoint();
+//  }
 
   private static final String[] AUTH_WHITELIST = {
       // -- swagger ui

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
@@ -124,44 +124,6 @@ public class BuildingService {
     return building;
   }
 
-  public BuildingDTO createBuildingDTO(Building building) {
-    BuildingDTO buildingDTO = new BuildingDTO();
-
-    buildingDTO.setId(building.getId());
-    buildingDTO.setType(building.getType());
-
-    int buildingLevel = building.getLevel();
-    if (LocalDateTime.now().isBefore(building.getFinishedAt())) {
-      buildingLevel -= 1;
-    }
-    buildingDTO.setLevel(buildingLevel);
-
-    Timestamp startedAt = Timestamp.valueOf(building.getStartedAt());
-    buildingDTO.setStartedAt(startedAt);
-    Timestamp finishedAt = Timestamp.valueOf(building.getFinishedAt());
-    buildingDTO.setFinishedAt(finishedAt);
-    return buildingDTO;
-  }
-
-  public BuildingsDTO createBuildingsDTO(String username) {
-    List<BuildingDTO> buildingDTOList = new ArrayList<>();
-    Kingdom kingdom = kingdomRepository.findKingdomByUser_Username(username).get();
-    ArrayList<Building> buildingList = findBuildingsByKingdom(kingdom.getId());
-
-    for (Building building : buildingList) {
-      BuildingDTO buildingDTO = new BuildingDTO();
-      buildingDTO.setId(building.getId());
-      buildingDTO.setType(building.getType());
-      buildingDTO.setLevel(building.getLevel());
-      Timestamp startedAt = Timestamp.valueOf(building.getStartedAt());
-      buildingDTO.setStartedAt(startedAt);
-      Timestamp finishedAt = Timestamp.valueOf(building.getFinishedAt());
-      buildingDTO.setFinishedAt(finishedAt);
-      buildingDTOList.add(buildingDTO);
-    }
-    return new BuildingsDTO(buildingDTOList);
-  }
-
   public boolean isValidLevel(Integer upgradeLevelAsked, Integer currentLevel, Long kingdomId, BuildingTypeENUM type) {
 
     if (upgradeLevelAsked == null || upgradeLevelAsked < 1 || upgradeLevelAsked > 3) return false;
@@ -213,6 +175,36 @@ public class BuildingService {
     prodBuildingToUpgrade.setProductionRate(ProductionBuilding.PROD_RATE_PER_LEVEL * prodBuildingToUpgrade.getLevel());
     productionBuildingRepository.save(prodBuildingToUpgrade);
     return prodBuildingToUpgrade;
+  }
+
+  public BuildingDTO createBuildingDTO(Building building) {
+    BuildingDTO buildingDTO = new BuildingDTO();
+
+    buildingDTO.setId(building.getId());
+    buildingDTO.setType(building.getType());
+
+    int buildingLevel = building.getLevel();
+    if (LocalDateTime.now().isBefore(building.getFinishedAt())) {
+      buildingLevel -= 1;
+    }
+    buildingDTO.setLevel(buildingLevel);
+
+    Timestamp startedAt = Timestamp.valueOf(building.getStartedAt());
+    buildingDTO.setStartedAt(startedAt);
+    Timestamp finishedAt = Timestamp.valueOf(building.getFinishedAt());
+    buildingDTO.setFinishedAt(finishedAt);
+    return buildingDTO;
+  }
+
+  public BuildingsDTO createBuildingsDTO(String username) {
+    List<BuildingDTO> buildingDTOList = new ArrayList<>();
+    Kingdom kingdom = kingdomRepository.findKingdomByUser_Username(username).get();
+    ArrayList<Building> buildingList = findBuildingsByKingdom(kingdom.getId());
+
+    for (Building building : buildingList) {
+      buildingDTOList.add(createBuildingDTO(building));
+    }
+    return new BuildingsDTO(buildingDTOList);
   }
 
 }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
@@ -126,9 +126,16 @@ public class BuildingService {
 
   public BuildingDTO createBuildingDTO(Building building) {
     BuildingDTO buildingDTO = new BuildingDTO();
+
     buildingDTO.setId(building.getId());
     buildingDTO.setType(building.getType());
-    buildingDTO.setLevel(building.getLevel());
+
+    int buildingLevel = building.getLevel();
+    if (LocalDateTime.now().isBefore(building.getFinishedAt())) {
+      buildingLevel -= 1;
+    }
+    buildingDTO.setLevel(buildingLevel);
+
     Timestamp startedAt = Timestamp.valueOf(building.getStartedAt());
     buildingDTO.setStartedAt(startedAt);
     Timestamp finishedAt = Timestamp.valueOf(building.getFinishedAt());

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
@@ -88,7 +88,11 @@ public class BuildingService {
     ArrayList<Farm> farms = findFarmsByKingdom(kingdomId);
 
     for (Farm farm : farms) {
-      foodProductionRate += farm.getProductionRate();
+      int farmProductionRate = farm.getProductionRate();
+      if (LocalDateTime.now().isBefore(farm.getFinishedAt())) {
+        farmProductionRate -= ProductionBuilding.PROD_RATE_PER_LEVEL;
+      }
+      foodProductionRate += farmProductionRate;
     }
     return foodProductionRate;
   }
@@ -98,7 +102,11 @@ public class BuildingService {
     ArrayList<Mine> mines = findMinesByKingdom(kingdomId);
 
     for (Mine mine : mines) {
-      goldProductionRate += mine.getProductionRate();
+      int mineProductionRate = mine.getProductionRate();
+      if (LocalDateTime.now().isBefore(mine.getFinishedAt())) {
+        mineProductionRate -= ProductionBuilding.PROD_RATE_PER_LEVEL;
+      }
+      goldProductionRate += mineProductionRate;
     }
     return goldProductionRate;
   }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
@@ -104,7 +104,6 @@ public class BuildingService {
   }
 
   public Building createBuilding(Kingdom kingdom, String type) {
-    Resource goldResource = resourceRepository.findResourceByTownhall_Kingdom_IdAndType(kingdom.getId(), ResourceTypeENUM.GOLD).get();
     Building building;
 
     if (type.equalsIgnoreCase(BuildingTypeENUM.FARM.toString())) {
@@ -117,10 +116,12 @@ public class BuildingService {
       building = null;
     }
 
+    Resource goldResource = resourceRepository.findResourceByTownhall_Kingdom_IdAndType(kingdom.getId(), ResourceTypeENUM.GOLD).get();
     int newGoldAmount = goldResource.getAmount() - Building.CREATION_COST;
     goldResource.setAmount(newGoldAmount);
     goldResource.setUpdateTime(LocalDateTime.now());
     resourceRepository.save(goldResource);
+
     return building;
   }
 

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/BuildingService.java
@@ -71,7 +71,7 @@ public class BuildingService {
     return buildingRepository.findBuildingsByKingdom_Id(kingdomId);
   }
 
-  public Building findBuildingByKingdomAndBuildingId(Long kingdomId, Long buildingId){
+  public Building findBuildingByKingdomAndBuildingId(Long kingdomId, Long buildingId) {
     return buildingRepository.findBuildingByKingdom_IdAndId(kingdomId, buildingId).orElse(null);
   }
 
@@ -155,14 +155,14 @@ public class BuildingService {
     return new BuildingsDTO(buildingDTOList);
   }
 
-  public boolean isValidLevel(Integer upgradeLevelAsked, Integer currentLevel, Long kingdomId, BuildingTypeENUM type){
+  public boolean isValidLevel(Integer upgradeLevelAsked, Integer currentLevel, Long kingdomId, BuildingTypeENUM type) {
 
     if (upgradeLevelAsked == null || upgradeLevelAsked < 1 || upgradeLevelAsked > 3) return false;
     if (upgradeLevelAsked == currentLevel) return false;
 
     Integer townhallLevel = townhallRepository.findTownhallsByKingdom_Id(kingdomId).get(0).getLevel();
 
-    if (!type.equals(BuildingTypeENUM.TOWNHALL)){
+    if (!type.equals(BuildingTypeENUM.TOWNHALL)) {
       if (upgradeLevelAsked > townhallLevel) return false;
     }
 
@@ -189,7 +189,7 @@ public class BuildingService {
     return buildingToUpgrade;
   }
 
-  public Townhall upgradeTownhall(Long kingdomId, Long buildingId, Integer upgradeLevel){
+  public Townhall upgradeTownhall(Long kingdomId, Long buildingId, Integer upgradeLevel) {
     upgradeBuilding(kingdomId, buildingId, upgradeLevel);
 
     Townhall townhallToUpgrade = townhallRepository.findById(buildingId).get();

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/KingdomService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/KingdomService.java
@@ -82,7 +82,7 @@ public class KingdomService {
     kingdomDTO.setId(kingdom.getId());
     kingdomDTO.setKingdomName(kingdom.getKingdomName());
     kingdomDTO.setUserId(kingdom.getUser().getId());
-    kingdomDTO.setLocation(new LocationDTO(kingdom.getxCoord(),kingdom.getyCoord()));
+    kingdomDTO.setLocation(new LocationDTO(kingdom.getxCoord(), kingdom.getyCoord()));
     kingdomDTO.setSoldiers(soldierService.createSoldierDTOList(kingdom.getId()));
     kingdomDTO.setBuildings(buildingService.createBuildingsDTO(kingdom.getUser().getUsername()).getBuildings());
     kingdomDTO.setResources(productionService.createResourcesDTO(kingdom.getId()).getResources());

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/LeaderboardService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/LeaderboardService.java
@@ -31,6 +31,7 @@ public class LeaderboardService {
   public LeaderboardByBuildingsDTO createLeaderboardByBuildings() {
     List<LeaderboardBuildingsDTO> leaderboardBuildingsDTOList = new ArrayList<>();
     ArrayList<Kingdom> kingdomList = kingdomRepository.findAll();
+
     for (Kingdom kingdom : kingdomList) {
       LeaderboardBuildingsDTO leaderboardBuildingsDTO = new LeaderboardBuildingsDTO();
       leaderboardBuildingsDTO.setKingdomName(kingdom.getKingdomName());
@@ -43,6 +44,7 @@ public class LeaderboardService {
   public LeaderboardBySoldiersDTO createLeaderboardBySoldiers() {
     List<LeaderboardSoldiersDTO> leaderboardBySoldiersDTOList = new ArrayList<>();
     ArrayList<Kingdom> kingdomList = kingdomRepository.findAll();
+
     for (Kingdom kingdom : kingdomList) {
       LeaderboardSoldiersDTO leaderboardSoldiersDTO = new LeaderboardSoldiersDTO();
       leaderboardSoldiersDTO.setKingdomName(kingdom.getKingdomName());
@@ -51,4 +53,5 @@ public class LeaderboardService {
     }
     return new LeaderboardBySoldiersDTO(leaderboardBySoldiersDTOList);
   }
+
 }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/SoldierService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/SoldierService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,11 @@ public class SoldierService {
     ArrayList<Soldier> soldiers = findSoldiersByKingdom(kingdomId);
 
     for (Soldier soldier : soldiers) {
-      consumptionRate += soldier.getConsumptionRate();
+      int soldierConsumptionRate = soldier.getConsumptionRate();
+      if (LocalDateTime.now().isBefore(soldier.getFinishedAt())) {
+        soldierConsumptionRate -= Soldier.CONSUMPTION_RATE_PER_LEVEL;
+      }
+      consumptionRate += soldierConsumptionRate;
     }
     return consumptionRate;
   }

--- a/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/SoldierService.java
+++ b/src/main/java/com/greenfoxacademy/goddesstribesbackend/services/SoldierService.java
@@ -44,4 +44,5 @@ public class SoldierService {
     }
     return listOfSoldiers;
   }
+
 }

--- a/src/test/java/com/greenfoxacademy/goddesstribesbackend/controllers/LeaderboardControllerTest.java
+++ b/src/test/java/com/greenfoxacademy/goddesstribesbackend/controllers/LeaderboardControllerTest.java
@@ -47,20 +47,20 @@ public class LeaderboardControllerTest {
   private LeaderboardService leaderboardService;
 
   @BeforeClass
-  public static void init(){
+  public static void init() {
     String username = "Agi";
     String password = "lujzi123";
     jwtToken = JWTUtility.generateToken(username);
     User user = new User(username, password);
     contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
-        MediaType.APPLICATION_JSON.getSubtype(),
-        Charset.forName("utf8"));
+            MediaType.APPLICATION_JSON.getSubtype(),
+            Charset.forName("utf8"));
   }
 
   @Test
   public void buildingListSholudReturnUnauthorizedIfNoTokenGiven() throws Exception {
     mockMvc.perform(get("/leaderboard/buildings"))
-        .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized());
   }
 
   @Test
@@ -71,17 +71,17 @@ public class LeaderboardControllerTest {
     when(leaderboardService.createLeaderboardByBuildings()).thenReturn(leaderboardByBuildingsDTO);
 
     mockMvc.perform(get("/leaderboard/buildings")
-        .header("Authorization", "Bearer " + jwtToken))
-        .andExpect(status().is(200))
-        .andExpect(content().contentType(contentType))
-        .andExpect(jsonPath("$.leaderboard[0].kingdomName", is("Agi's kingdom")))
-        .andExpect(jsonPath("$.leaderboard[0].buildings", is(3)));
+            .header("Authorization", "Bearer " + jwtToken))
+            .andExpect(status().is(200))
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$.leaderboard[0].kingdomName", is("Agi's kingdom")))
+            .andExpect(jsonPath("$.leaderboard[0].buildings", is(3)));
   }
 
   @Test
   public void solidierListSholudReturnUnauthorizedIfNoTokenGiven() throws Exception {
     mockMvc.perform(get("/leaderboard/soldiers"))
-        .andExpect(status().isUnauthorized());
+            .andExpect(status().isUnauthorized());
   }
 
   @Test
@@ -92,11 +92,11 @@ public class LeaderboardControllerTest {
     when(leaderboardService.createLeaderboardBySoldiers()).thenReturn(leaderboardBySoldiersDTO);
 
     mockMvc.perform(get("/leaderboard/soldiers")
-        .header("Authorization", "Bearer " + jwtToken))
-        .andExpect(status().is(200))
-        .andExpect(content().contentType(contentType))
-        .andExpect(jsonPath("$.leaderboard[0].kingdomName", is("Agi's kingdom")))
-        .andExpect(jsonPath("$.leaderboard[0].soldiers", is(5)));
+            .header("Authorization", "Bearer " + jwtToken))
+            .andExpect(status().is(200))
+            .andExpect(content().contentType(contentType))
+            .andExpect(jsonPath("$.leaderboard[0].kingdomName", is("Agi's kingdom")))
+            .andExpect(jsonPath("$.leaderboard[0].soldiers", is(5)));
   }
 
 }

--- a/src/test/java/com/greenfoxacademy/goddesstribesbackend/controllers/ResourceControllerTest.java
+++ b/src/test/java/com/greenfoxacademy/goddesstribesbackend/controllers/ResourceControllerTest.java
@@ -56,8 +56,8 @@ public class ResourceControllerTest {
     user = new User(username, password);
     kingdom = new Kingdom(username + "s kingdom", user);
     contentType = new MediaType(MediaType.APPLICATION_JSON.getType(),
-                                MediaType.APPLICATION_JSON.getSubtype(),
-                                Charset.forName("utf8"));
+            MediaType.APPLICATION_JSON.getSubtype(),
+            Charset.forName("utf8"));
   }
 
   @Test


### PR DESCRIPTION
A frontend kérésére megoldottam, hogy a születés alatt álló épületek level-je 0, az upgrade alatt álló épületek levelje pedig 1-gyel kevesebb, vagyis 1 vagy 2 értékkel mennek ki a frontendnek. (Csak a tényleges megszületés után lesz a level értéke 1, upgrade esetén pedig 2 vagy 3.) 
(Az adatbázisba viszont rögtön bekerül a születés/upgrade utáni level, úgy mint eddig.)

Foglalkoztam azzal is, hogy a születés alatt álló farmok/bányák/soldierek még ne termeljenek/egyenek semmit, upgrade esetén pedig az előző szinten termelnek/esznek egészen addig, amíg felupgradelődnek. 